### PR TITLE
Add PR auto-fix workflow and version sync script

### DIFF
--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -7,6 +7,7 @@ on:
   pull_request_target:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,14 +15,14 @@ permissions:
 
 jobs:
   auto-fix:
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Set up Python 3.10
@@ -60,4 +61,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Apply PR auto-fixes"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -1,0 +1,63 @@
+name: PR auto-fix
+
+env:
+  package-name: labmate
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-fix:
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install auto-fix dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Apply Ruff auto-fixes when needed
+        run: |
+          if ! ruff check . >/dev/null 2>&1 || ! ruff format --check . >/dev/null 2>&1; then
+            ruff check . --fix
+            ruff format .
+          else
+            echo "Ruff checks already pass; skipping formatting fixes."
+          fi
+
+      - name: Bump version when PR version is not greater than main
+        run: |
+          git fetch origin main
+          main_version=$(git show origin/main:${{ env.package-name }}/__config__.py | grep '__version__' | cut -d'"' -f2)
+          python scripts/sync_version.py "$main_version" --fix
+
+      - name: Commit auto-fixes back to the PR branch
+        run: |
+          if git diff --quiet; then
+            echo "No auto-fix changes were needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Apply PR auto-fixes"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/python-ci-main.yml
+++ b/.github/workflows/python-ci-main.yml
@@ -72,18 +72,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Get PR branch version
-        id: get_pr_version
-        run: |
-          pr_version=$(grep '__version__' ${{env.package-name}}/__config__.py | cut -d'"' -f2)
-          echo "PR branch version: $pr_version"
-          echo "pr_version=$pr_version" >> "$GITHUB_OUTPUT"
+        with:
+          fetch-depth: 0
 
       - name: Get main branch version
         id: get_main_version
         run: |
-          git fetch origin
+          git fetch origin main
           echo "Config file:"
           git show origin/main:${{env.package-name}}/__config__.py
           main_version=$(git show origin/main:${{env.package-name}}/__config__.py | grep '__version__' | cut -d'"' -f2)
@@ -92,13 +87,4 @@ jobs:
 
       - name: Compare versions
         run: |
-          echo "Main branch version: ${{ steps.get_main_version.outputs.main_version }}"
-          echo "PR branch version: ${{ steps.get_pr_version.outputs.pr_version }}"
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            if [ "${{ steps.get_main_version.outputs.main_version }}" = "${{ steps.get_pr_version.outputs.pr_version }}" ]; then
-              echo "Error: Version is the same as on the main branch"
-              exit 1
-            else
-              echo "Ok: Version is different from the main branch"
-            fi
-          fi
+          python scripts/sync_version.py "${{ steps.get_main_version.outputs.main_version }}" --check

--- a/labmate/__config__.py
+++ b/labmate/__config__.py
@@ -1,3 +1,3 @@
 """This file contains all package constants."""
 
-__version__ = "0.10.8"
+__version__ = "0.10.6"

--- a/labmate/__config__.py
+++ b/labmate/__config__.py
@@ -1,3 +1,3 @@
 """This file contains all package constants."""
 
-__version__ = "0.10.6"
+__version__ = "0.10.8"

--- a/labmate/__config__.py
+++ b/labmate/__config__.py
@@ -1,3 +1,3 @@
 """This file contains all package constants."""
 
-__version__ = "0.10.7"
+__version__ = "0.10.8"

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Check or fix the package version against the main branch version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+CONFIG_PATH = Path("labmate/__config__.py")
+VERSION_RE = re.compile(r'(__version__\s*=\s*")([0-9]+(?:\.[0-9]+){2})(")')
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    try:
+        parts = tuple(int(part) for part in version.split("."))
+    except ValueError as exc:
+        raise SystemExit(f"Invalid semantic version '{version}': {exc}") from exc
+    if len(parts) != 3:
+        raise SystemExit(f"Invalid semantic version '{version}': expected MAJOR.MINOR.PATCH")
+    return parts
+
+
+def read_current_version(config_path: Path) -> tuple[str, tuple[int, int, int], str]:
+    text = config_path.read_text()
+    match = VERSION_RE.search(text)
+    if not match:
+        raise SystemExit(f"Unable to find __version__ in {config_path}")
+    version_str = match.group(2)
+    return text, parse_version(version_str), version_str
+
+
+def bump_patch(version: tuple[int, int, int]) -> tuple[int, int, int]:
+    major, minor, patch = version
+    return (major, minor, patch + 1)
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def run_check(main_version: tuple[int, int, int], current_version: tuple[int, int, int]) -> int:
+    if current_version <= main_version:
+        print(
+            "Error: current version must be greater than main version "
+            f"({format_version(current_version)} <= {format_version(main_version)})"
+        )
+        return 1
+    print(
+        "Version check passed: current version is greater than main version "
+        f"({format_version(current_version)} > {format_version(main_version)})"
+    )
+    return 0
+
+
+def run_fix(
+    config_path: Path,
+    text: str,
+    current_version: tuple[int, int, int],
+    current_str: str,
+    main_version: tuple[int, int, int],
+) -> int:
+    if current_version > main_version:
+        print(
+            "No version update needed: current version already exceeds main version "
+            f"({current_str} > {format_version(main_version)})"
+        )
+        return 0
+
+    new_version = bump_patch(main_version)
+    new_version_str = format_version(new_version)
+    updated_text = VERSION_RE.sub(rf"\g<1>{new_version_str}\g<3>", text, count=1)
+    config_path.write_text(updated_text)
+    print(f"Updated version from {current_str} to {new_version_str}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "main_version",
+        help="Version currently on main, for example 0.10.7",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the current version is not greater than main",
+    )
+    mode.add_argument(
+        "--fix",
+        action="store_true",
+        help="Bump the current version if it is not greater than main",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(CONFIG_PATH),
+        help="Path to the config file that contains __version__",
+    )
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    main_version = parse_version(args.main_version)
+    text, current_version, current_str = read_current_version(config_path)
+
+    if args.check:
+        return run_check(main_version, current_version)
+    return run_fix(config_path, text, current_version, current_str, main_version)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Add automation to apply code formatting fixes on incoming PRs and ensure package version on a PR is strictly greater than `main` to prevent accidental regressions.
- Centralize version comparison and bump logic into a reusable script to keep CI and PR workflows consistent.

### Description
- Add a new GitHub Actions workflow `/.github/workflows/pr-autofix.yml` that runs on PRs, installs `ruff`, applies auto-fixes (`ruff check --fix` and `ruff format`), invokes `scripts/sync_version.py --fix` to bump the package version when needed, and commits changes back to the PR branch.
- Add `scripts/sync_version.py` which provides `--check` and `--fix` modes to parse `MAJOR.MINOR.PATCH` from `labmate/__config__.py`, compare against the `main` version, and bump the patch number when required.
- Update `/.github/workflows/python-ci-main.yml` to use a full fetch (`fetch-depth: 0`), fetch `origin/main` for the config file, and delegate version validation to `scripts/sync_version.py --check` instead of the previous inline shell comparison.
- Ensure CI installs and runs `ruff` for linting and formatting checks in the existing workflow steps.

### Testing
- No automated tests were executed as part of this change; the new workflows will run on subsequent PRs and `main` CI runs to perform linting and version checks automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb30886114832393645e8fa9c6cf94)